### PR TITLE
Add support for old bedrock edition worlds

### DIFF
--- a/ImageMap4.CMD/Models/BedrockWorld.cs
+++ b/ImageMap4.CMD/Models/BedrockWorld.cs
@@ -62,7 +62,7 @@ public class BedrockWorld : World
                             new NbtCompound("block_entity_data") {
                                 new NbtString("id", structure.GlowingFrames ? "GlowItemFrame" : "ItemFrame"),
                                 new NbtCompound("Item") {
-                                    new NbtString("Name", "minecraft:filled_map"),
+                                    new NbtShort("id", 358),
                                     new NbtByte("Count", 1),
                                     new NbtCompound("tag") {
                                         new NbtLong("map_uuid", id.Value)


### PR DESCRIPTION
old worlds have a different id for map item. this means that if you use Image Map for old worlds, then the frames with maps will be empty. At the moment bedrock edition and Image Map use id: minecraft:filled_map, but older versions of Bedrock edition use 358 and minecraft:map.

I fixed the error by replacing the line of code in Image Map with `new NbtShort("id", 358),` now there is no error and there is compatibility with all versions of bedrock edition, because if load the structure with the old id 358 at item map in the new world, the game will just automatically update it to minecraft:map or minecraft:filled_map